### PR TITLE
fixed floating point approx

### DIFF
--- a/src/components/home/PopUpItem.vue
+++ b/src/components/home/PopUpItem.vue
@@ -22,9 +22,9 @@ import InfoIcon from '@/assets/icons/info.svg?component'
                     <img :src="imgPath" id="photo">
                     <span>{{ getBldg().meta.name }}</span>
                 </div>
-                <p id="heat" v-if="interpretHeat()"><b style="color:var(--heatColor);">{{ interpretHeat() }}</b> (~{{ getBldg().meta.heat.toFixed(2)*100 }}%)</p>
+                <p id="heat" v-if="interpretHeat()"><b style="color:var(--heatColor);">{{ interpretHeat() }}</b> (~{{ Math.trunc(getBldg().meta.heat.toFixed(2)*100) }}%)</p>
                 <p id="heat" v-else><b>N/A</b></p>
-                <p id="flow" v-if="interpretFlow()">+ {{ interpretFlow() }} (~{{ getBldg().meta.flow.toFixed(2)*100 }}%)&emsp;</p>
+                <p id="flow" v-if="interpretFlow()">+ {{ interpretFlow() }} (~{{ Math.trunc(getBldg().meta.flow.toFixed(2)*100) }}%)&emsp;</p>
                 <p id="time" ref="mySpan">{{ getRealTime(global.time) }}</p>
                 <span v-if="getHist()"> 
                     <InfoIcon class="info"/>


### PR DESCRIPTION
In the HTML for the popup, it was set to get the heat (ex 0.55) and multiply by 100 (ex 55%)
The issue with this is that the heat was floating point and multiplying by 100 caused a weird issue with floating point approx (where it showed something like ~55.0000000000001%). 
I just added a Math.trunc around the function for heat and it fixes the approximation issue.